### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 ## 注意事項
 - グラフィック設定のレジストリ内容を書き換えています。
 - 本プログラムの使用に伴ういかなる事象についての責任は負いかねますので、ご利用は自己責任でお願いします。
+- 設定画面の表示について: 本プログラムで設定したFPS上限は、ゲーム内の設定画面には反映されません。例えば、ゲーム内でFPS上限が30と表示されている場合でも、実際にはPowerPomPomで設定した上限（例：120FPS）が反映されています。実際のFPSを確認する際は、グラフィックボードのFPSカウンターなどをご利用ください。
 
 ## FAQ
 ### Q. なんで120までしか出ないの？
@@ -32,3 +33,15 @@ A. メモリのアドレスが流石に原神とは異なるのか、PowerPaimon
    - If an error occurred while launching, please launch the HSR game first and try again.
 1. Control the FPS Slider to change the max fps cap.
    - Max fps value will save to the registry automatically, so you don't have to launch this software again.
+
+## Notes
+- This software modifies the graphics settings in the Windows registry.
+- The developers are not responsible for any issues that may arise from the use of this software. Please use it at your own risk.
+- Display of FPS Cap in the Settings: The FPS cap set by PowerPomPom is not reflected in the in-game settings menu. For example, even if the game displays the cap as 30 FPS, the actual limit set by PowerPomPom (e.g., 120 FPS) will be applied. To verify the actual FPS, please use a graphics card FPS counter or similar tools.
+
+## FAQ
+### Q. Why is the limit capped at 120 FPS?
+A. While the registry can be modified to go beyond 120 FPS, it seems the game resets to 60 FPS upon launch, likely because it doesn't support higher values.
+
+### Q. Why not override process memory like PowerPaimon?
+A. The memory addresses for Honkai Star Rail appear to differ significantly from those in Genshin Impact. Modifying the PowerPaimon source code only slightly was not enough to make it work. It might be possible with extensive memory searching, but as I'm not an expert, I'm avoiding it for now. If I can figure out a reliable method in the future, I'd like to extend the cap to 240 FPS or beyond.


### PR DESCRIPTION
READMEに、ゲーム内でのFPS上限の表示に関する注意書きを追加しました。

この更新は、PowerPomPomを利用する際のよくある誤解を解消するためのものです。PowerPomPomで設定したFPS上限が、ゲーム内の設定メニューに正しく反映されない場合があります。たとえば、ゲーム内設定が30FPSと表示していても、実際にはPowerPomPomで設定した上限（例: 120FPS）が適用されています。この情報を「注意事項」に追加し、日本語および英語でわかりやすく記載しました。

変更内容:
- PowerPomPomで設定したFPS上限が、ゲーム内設定に反映されない可能性についての説明を追加しました。
- 実際のFPSはグラフィックボードのFPSカウンターなどで確認するよう案内を追加しました。
- FAQにも関連情報を追加し、ユーザーがFPS設定の効果を確認しやすくしました。

この変更により、ユーザーがPowerPomPomの動作を正しく理解し、誤解を防ぐことができるようになります。

---

Added clarification to README regarding FPS cap behavior in-game.

This update addresses a common source of confusion for users. The FPS cap set by PowerPomPom may not appear accurately in the in-game settings menu. For example, while the in-game settings may display a cap of 30 FPS, the actual cap (e.g., 120 FPS) set by PowerPomPom is applied. This information has been added to both the Japanese and English sections of the README under "Notes" for better clarity.

Changes include:
- Added a note explaining that the FPS cap may not be reflected in the in-game settings.
- Suggested users verify actual FPS using graphics card counters or similar tools.
- Updated FAQ to include relevant information for users seeking to confirm their FPS settings.

This should help users avoid confusion and confirm that PowerPomPom is working as expected.